### PR TITLE
Prevent remove one _context twice if we have no default route.

### DIFF
--- a/src/utils/create-router.js
+++ b/src/utils/create-router.js
@@ -53,7 +53,10 @@ const createRouter = options => {
 
   const handleRouteChange = location => {
     let found = false
-    if (_content) _content.destroy()
+    if (_content) {
+      _content.destroy()
+      _content = null
+    }
 
     for (let path in options) {
       if (Object.prototype.hasOwnProperty.call(options, path)) {


### PR DESCRIPTION
Subj. trivial fix. 