### PR TITLE
Substitute history

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ yarn add svelte-router
   import Welcome from './Welcome.html'
   import Animal from './Animal.html'
 
+  // import custom (browser) history
+  import history from './history'
+
   const { createRouter, RouterLink } = SvelteRouter
 
   const router = createRouter({
@@ -58,7 +61,7 @@ yarn add svelte-router
         }
       }
     }
-  })
+  }, history)
 
   export default {
     oncreate () {

--- a/build/index.html
+++ b/build/index.html
@@ -10,6 +10,6 @@
 <body>
   <div id="example"></div>
 
-  <script src="./svelte-router.js"></script>
+  <script src="/svelte-router.js"></script>
 </body>
 </html>

--- a/example/app.html
+++ b/example/app.html
@@ -15,6 +15,9 @@
   import Hello from './Hello.html'
   import NotFound from './NotFound.html'
 
+  // import custom (browser) history
+  import history from './history'
+
   const { createRouter, RouterLink } = SvelteRouter
 
   const store = new Store({
@@ -39,7 +42,7 @@
       },
     },
     default: NotFound
-  })
+  }, history)
   createRouter.listen(() => {
     console.log('router changed')
   })

--- a/example/history.js
+++ b/example/history.js
@@ -1,4 +1,4 @@
-import createHistory from 'history/createHashHistory'
+import createHistory from 'history/createBrowserHistory'
 
 const history = createHistory()
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,6 +45,7 @@ if (process.env.NODE_ENV === 'production') {
   config.input = './example/main.js'
   config.plugins.unshift(
     serve({
+      historyApiFallback: true,
       contentBase: ['lib', 'build']
     }),
     livereload('release')

--- a/src/components/RouterLink.html
+++ b/src/components/RouterLink.html
@@ -3,7 +3,6 @@
 </a>
 
 <script>
-  import history from '../utils/history'
   const activedClassName = 'router-link-active'
   
   export default {
@@ -11,7 +10,7 @@
       return {
         replace: false,
         to: '/',
-        basePath: '#',
+        basePath: '',
         active: false,
         class: '',
         activeClass: activedClassName,

--- a/src/utils/create-router.js
+++ b/src/utils/create-router.js
@@ -1,4 +1,4 @@
-import history from './history'
+import createDefaultHistory from 'history/createHashHistory'
 
 const DYNAMIC_PATH_REGEX = '[a-zA-Z]+'
 const DEFAULT_ROUTE = 'default'
@@ -46,10 +46,16 @@ const getContent = (options, path, target, pathVariables) => {
   })
 }
 
-const createRouter = options => {
+const createRouter = (options, customHistory) => {
   let _target // target DOM
   let _unlisten // history listener
   let _content // route instance
+  let history = customHistory || createDefaultHistory()
+
+  // define getter history proeprty
+  Object.defineProperty(this, 'history', {
+    get: () => history
+  })
 
   const handleRouteChange = location => {
     let found = false


### PR DESCRIPTION
Make it possible to substitute history object  (history/createHashHistory) with custom history object (eg: history/createBrowserHistory) in order to remove hash from url:

**http://localhost:10001/#/hello/world** becomes **http://localhost:10001/hello/world**